### PR TITLE
PHP7 Compatibility Fix

### DIFF
--- a/lib/Amazon/MarketplaceWebServiceSellers/Model/ResponseHeaderMetadata.php
+++ b/lib/Amazon/MarketplaceWebServiceSellers/Model/ResponseHeaderMetadata.php
@@ -29,12 +29,12 @@ class MarketplaceWebServiceSellers_Model_ResponseHeaderMetadata {
   private $metadata = array();
 
   public function __construct($requestId = null, $responseContext = null, $timestamp = null,
-                              $quotaMax = null, $quotaMax = null, $quotaResetsAt = null) {
+                              $quotaMax = null, $quotaRemaining = null, $quotaResetsAt = null) {
     $this->metadata[self::REQUEST_ID] = $requestId;
     $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
     $this->metadata[self::TIMESTAMP] = $timestamp;
     $this->metadata[self::QUOTA_MAX] = $quotaMax;
-    $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+    $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
     $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
   }
 


### PR DESCRIPTION
Similar to https://github.com/amzn/amazon-payments-magento-plugin/pull/252

When trying to save the payment settings in Magento with PHP7, we get a PHP error because identical parameter names are no longer supported.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
